### PR TITLE
Refactor WeakSteamParallelMultiBlockMachine to extend SteamParallelMultiblockMachine

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
@@ -3,7 +3,6 @@ package com.ghostipedia.cosmiccore.common.machine.multiblock.steam;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDisplayUIMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
@@ -13,7 +12,7 @@ import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 
 import org.jetbrains.annotations.NotNull;
 
-public class WeakSteamParallelMultiBlockMachine extends SteamParallelMultiblockMachine implements IDisplayUIMachine {
+public class WeakSteamParallelMultiBlockMachine extends SteamParallelMultiblockMachine {
 
     // if in millibuckets, this is 0.5, Meaning 0.5mb of steam -> 1 EU
     private static final double CONVERSION_RATE = 0.5D;

--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
@@ -3,12 +3,12 @@ package com.ghostipedia.cosmiccore.common.machine.multiblock.steam;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -29,9 +29,9 @@ public class WeakSteamParallelMultiBlockMachine extends SteamParallelMultiblockM
 
     public static ModifierFunction recipeModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
         if (RecipeHelper.getRecipeEUtTier(recipe) > GTValues.LV) return ModifierFunction.NULL;
-//        long euTick = RecipeHelper.getRecipeEUtTier(recipe);
+        // long euTick = RecipeHelper.getRecipeEUtTier(recipe);
         int parallel = ParallelLogic.getParallelAmount(machine, recipe, 4);
-//         double eutMulti = (euTick * 0.5 * parallel <= 32) ? (parallel * 0.5) : (32.0 / euTick);
+        // double eutMulti = (euTick * 0.5 * parallel <= 32) ? (parallel * 0.5) : (32.0 / euTick);
 
         return ModifierFunction.builder()
                 .inputModifier(ContentModifier.multiplier(parallel))

--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
@@ -1,86 +1,38 @@
 package com.ghostipedia.cosmiccore.common.machine.multiblock.steam;
 
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
-import com.gregtechceu.gtceu.api.gui.GuiTextures;
-import com.gregtechceu.gtceu.api.gui.UITemplate;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDisplayUIMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
-import com.gregtechceu.gtceu.api.machine.steam.SteamEnergyRecipeHandler;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
-import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
-import com.gregtechceu.gtceu.common.data.GTMaterials;
-import com.gregtechceu.gtceu.config.ConfigHolder;
-
-import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
-import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
-import com.lowdragmc.lowdraglib.gui.widget.ComponentPanelWidget;
-import com.lowdragmc.lowdraglib.gui.widget.DraggableScrollableWidgetGroup;
-import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
-
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
-import net.minecraft.world.entity.player.Player;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
+public class WeakSteamParallelMultiBlockMachine extends SteamParallelMultiblockMachine implements IDisplayUIMachine {
 
-public class WeakSteamParallelMultiBlockMachine extends WorkableMultiblockMachine implements IDisplayUIMachine {
-
-    public static final int MAX_PARALLELS = 4;
-
-    @Nullable
-    private SteamEnergyRecipeHandler steamEnergy = null;
-
-    // if in millibuckets, this is 0.5, Meaning 2mb of steam -> 1 EU
+    // if in millibuckets, this is 0.5, Meaning 0.5mb of steam -> 1 EU
     private static final double CONVERSION_RATE = 0.5D;
 
     public WeakSteamParallelMultiBlockMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
+        setMaxParallels(4);
     }
 
     @Override
-    public void onStructureFormed() {
-        super.onStructureFormed();
-        for (var part : getParts()) {
-            var handlers = part.getRecipeHandlers();
-            for (var hl : handlers) {
-                if (!hl.isValid(IO.IN)) continue;
-                for (var fluidHandler : hl.getCapability(FluidRecipeCapability.CAP)) {
-                    if (!(fluidHandler instanceof NotifiableFluidTank nft)) continue;
-                    if (nft.isFluidValid(0, GTMaterials.Steam.getFluid(1)) &&
-                            PartAbility.STEAM.isApplicable(part.self().getDefinition().getBlock())) {
-                        steamEnergy = new SteamEnergyRecipeHandler(nft, CONVERSION_RATE);
-                        addHandlerList(RecipeHandlerList.of(IO.IN, steamEnergy));
-                        return;
-                    }
-
-                }
-            }
-        }
-        if (steamEnergy == null) {
-            onStructureInvalid();
-        }
+    public double getConversionRate() {
+        return CONVERSION_RATE;
     }
 
     public static ModifierFunction recipeModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
         if (RecipeHelper.getRecipeEUtTier(recipe) > GTValues.LV) return ModifierFunction.NULL;
-        long euTick = RecipeHelper.getRecipeEUtTier(recipe);
+//        long euTick = RecipeHelper.getRecipeEUtTier(recipe);
         int parallel = ParallelLogic.getParallelAmount(machine, recipe, 4);
-        double eutMulti = (euTick * 0.5 * parallel <= 32) ? (parallel * 0.5) : (32.0 / euTick);
+//         double eutMulti = (euTick * 0.5 * parallel <= 32) ? (parallel * 0.5) : (32.0 / euTick);
 
         return ModifierFunction.builder()
                 .inputModifier(ContentModifier.multiplier(parallel))
@@ -88,57 +40,5 @@ public class WeakSteamParallelMultiBlockMachine extends WorkableMultiblockMachin
                 .durationMultiplier(parallel * 0.75)
                 .parallels(parallel)
                 .build();
-    }
-
-    @Override
-    public void addDisplayText(List<Component> textList) {
-        IDisplayUIMachine.super.addDisplayText(textList);
-        if (isFormed()) {
-            var handlers = getCapabilitiesFlat(IO.IN, EURecipeCapability.CAP);
-            if (!handlers.isEmpty() && handlers.get(0) instanceof SteamEnergyRecipeHandler steamHandler) {
-                if (steamHandler.getCapacity() > 0) {
-                    long steamStored = steamHandler.getStored();
-                    textList.add(Component.translatable("gtceu.multiblock.steam.steam_stored", steamStored,
-                            steamHandler.getCapacity()));
-                }
-            }
-
-            if (!isWorkingEnabled()) {
-                textList.add(Component.translatable("gtceu.multiblock.work_paused"));
-
-            } else if (isActive()) {
-                textList.add(Component.translatable("gtceu.multiblock.running"));
-                int currentProgress = (int) (recipeLogic.getProgressPercent() * 100);
-                textList.add(Component.translatable("gtceu.multiblock.parallel", MAX_PARALLELS));
-                textList.add(Component.translatable("gtceu.multiblock.progress_percent", currentProgress));
-            } else {
-                textList.add(Component.translatable("gtceu.multiblock.idling"));
-            }
-
-            if (recipeLogic.isWaiting()) {
-                textList.add(Component.translatable("gtceu.multiblock.steam.low_steam")
-                        .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
-            }
-        }
-    }
-
-    @Override
-    public IGuiTexture getScreenTexture() {
-        return GuiTextures.DISPLAY_STEAM.get(ConfigHolder.INSTANCE.machines.steelSteamMultiblocks);
-    }
-
-    @Override
-    public ModularUI createUI(Player entityPlayer) {
-        var screen = new DraggableScrollableWidgetGroup(7, 4, 162, 121).setBackground(getScreenTexture());
-        screen.addWidget(new LabelWidget(4, 5, self().getBlockState().getBlock().getDescriptionId()));
-        screen.addWidget(new ComponentPanelWidget(4, 17, this::addDisplayText)
-                .setMaxWidthLimit(150)
-                .clickHandler(this::handleDisplayClick));
-        return new ModularUI(176, 216, this, entityPlayer)
-                .background(GuiTextures.BACKGROUND_STEAM.get(ConfigHolder.INSTANCE.machines.steelSteamMultiblocks))
-                .widget(screen)
-                .widget(UITemplate.bindPlayerInventory(entityPlayer.getInventory(),
-                        GuiTextures.SLOT_STEAM.get(ConfigHolder.INSTANCE.machines.steelSteamMultiblocks), 7, 134,
-                        true));
     }
 }


### PR DESCRIPTION
Deduplicates a bunch of code, and fixes Jade displaying energy usage as EU/t not MB/t.

<img width="613" height="557" alt="image" src="https://github.com/user-attachments/assets/5f3f001c-ab30-4d94-a4f9-95c4bedb4d15" />
