### PR TITLE
Fix Kryosyn Cracking Chamber pattern

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/KryosynCrackingChamber.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/KryosynCrackingChamber.java
@@ -47,7 +47,7 @@ public class KryosynCrackingChamber {
                             .or(abilities(PartAbility.INPUT_ENERGY).setExactLimit(1))
                             .or(abilities(PartAbility.PARALLEL_HATCH).setExactLimit(1))
                             .or(abilities(PartAbility.MAINTENANCE).setExactLimit(1)))
-                    .where('A', blocks(GTBlocks.CASING_ALUMINIUM_FROSTPROOF.get()))
+                    .where('C', blocks(GTBlocks.CASING_ALUMINIUM_FROSTPROOF.get()))
                     .build())
             // spotless:on
             .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_sturdy_hsse"),


### PR DESCRIPTION
Aluminium casing reused `A` as a character which soulstained alumina casing was already using