### PR TITLE
Fix: Chromatic Flotation Plant max recipe tier recognition

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ChromaticFlotationPlant.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ChromaticFlotationPlant.java
@@ -32,7 +32,6 @@ public class ChromaticFlotationPlant {
             .recipeModifiers(ELECTRIC_OVERCLOCK.apply(OverclockingLogic.NON_PERFECT_OVERCLOCK),
                     GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.BATCH_MODE)
             .appearanceBlock(GCYMBlocks.CASING_WATERTIGHT)
-            .generator(true)
             .pattern(definition -> FactoryBlockPattern.start()
                     .aisle("AAAAAAA", "AAAAAAA", "AAAAAAA", "AAAAAAA", "AAAAAAA")
                     .aisle("AAAAAAA", "ABCBCBA", "ABBBBBA", "ABBBBBA", "ABBBBBA")


### PR DESCRIPTION
Attempting to fix the issue where the Chromatic Flotation Plant cannot correctly recognize the maximum recipe tier.

Actually I just remove `.generator(true)` from the code and this fix resolves the bug where the Chromatic Flotation Plant could not correctly recognize the maximum recipe tier after testing. But it's unclear if this may cause other issues.