### PR TITLE
Allow Two Energy Hatches

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ArcaneCrucible.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ArcaneCrucible.java
@@ -42,7 +42,7 @@ public class ArcaneCrucible {
                             .or(abilities(PartAbility.IMPORT_FLUIDS).setPreviewCount(1))
                             .or(abilities(EXPORT_FLUIDS).setPreviewCount(1))
                             .or(abilities(IMPORT_EMBER).setPreviewCount(1))
-                            .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setExactLimit(1)))
+                            .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2)))
                     .where('B', blocks(CosmicBlocks.STEEL_ROSE_LIGHT.block().get()))
                     //
                     .build())

--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ArcaneCrucible.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/ArcaneCrucible.java
@@ -42,7 +42,8 @@ public class ArcaneCrucible {
                             .or(abilities(PartAbility.IMPORT_FLUIDS).setPreviewCount(1))
                             .or(abilities(EXPORT_FLUIDS).setPreviewCount(1))
                             .or(abilities(IMPORT_EMBER).setPreviewCount(1))
-                            .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(2)))
+                            .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setMinGlobalLimited(1)
+                                        .setMaxGlobalLimited(2)))
                     .where('B', blocks(CosmicBlocks.STEEL_ROSE_LIGHT.block().get()))
                     //
                     .build())


### PR DESCRIPTION
Fix the soft lock on luminized titanium that requires EV tier to unlock EV Hulls