### PR TITLE
Fix Drygmy overflow issue

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/data/recipe/CosmicRecipeModifiers.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/data/recipe/CosmicRecipeModifiers.java
@@ -123,6 +123,7 @@ public class CosmicRecipeModifiers {
         int multiplier = ParallelLogic.limitByOutputMerging(rlm, recipe, count, rlm::canVoidRecipeOutputs,
                 Collections.emptyList());
         if (multiplier == 1) return ModifierFunction.IDENTITY;
+        if (multiplier == 0) return ModifierFunction.NULL;
         return ModifierFunction.builder()
                 .outputModifier(ContentModifier.multiplier(multiplier))
                 .build();


### PR DESCRIPTION
Fix issue that Drygmy Grove continue working with no item output when output bus can't contain recipe output.