### PR TITLE
Fix steam assembler controller texture

### DIFF
--- a/src/generated/resources/assets/cosmiccore/models/block/machine/high_pressure_assembler.json
+++ b/src/generated/resources/assets/cosmiccore/models/block/machine/high_pressure_assembler.json
@@ -23,14 +23,14 @@
   "loader": "gtceu:machine",
   "machine": "cosmiccore:high_pressure_assembler",
   "texture_overrides": {
-    "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
+    "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing"
   },
   "variants": {
     "is_formed=false,recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
         }
@@ -40,7 +40,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
         }
@@ -50,7 +50,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
         }
@@ -60,7 +60,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
         }
@@ -70,7 +70,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
         }
@@ -80,7 +80,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
         }
@@ -90,7 +90,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
         }
@@ -100,7 +100,7 @@
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
+          "all": "cosmiccore:block/casings/solid/steel_plated_bronze_casing",
           "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
           "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
         }

--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/SteamAssembler.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/SteamAssembler.java
@@ -1,5 +1,6 @@
 package com.ghostipedia.cosmiccore.common.machine.multiblock.multi;
 
+import com.ghostipedia.cosmiccore.CosmicCore;
 import com.ghostipedia.cosmiccore.common.machine.multiblock.steam.WeakSteamParallelMultiBlockMachine;
 
 import com.gregtechceu.gtceu.GTCEu;
@@ -44,7 +45,7 @@ public class SteamAssembler {
                             .or(Predicates.abilities(PartAbility.STEAM).setExactLimit(1)))
                     .where('D', blocks(CASING_STEEL_GEARBOX.get()))
                     .build())
-            .model(createWorkableCasingMachineModel(GTCEu.id("block/casings/solid/machine_casing_bronze_plated_bricks"),
+            .model(createWorkableCasingMachineModel(CosmicCore.id("block/casings/solid/steel_plated_bronze_casing"),
                     GTCEu.id("block/multiblock/steam_oven"))
                     .andThen(b -> b.addDynamicRenderer(
                             () -> DynamicRenderHelper.makeBoilerPartRender(


### PR DESCRIPTION
It used the wrong casing texture (or so I've been told). Changes it from Steam Machine Casing to Steel Plated Bronze Casing

Before image:
<img width="1920" height="1080" alt="2025-12-02_01 52 11" src="https://github.com/user-attachments/assets/379f7e5f-edcb-4d7d-97d6-bc5a0e8c256b" />
