### PR TITLE
Large Steam Turbine keeps running if Dynamo full

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/logic/CosmicLargeTurbineMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/logic/CosmicLargeTurbineMachine.java
@@ -1,7 +1,6 @@
 package com.ghostipedia.cosmiccore.common.machine.multiblock.multi.logic;
 
 import com.gregtechceu.gtceu.api.capability.ITurbineMachine;
-import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;

--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/logic/CosmicLargeTurbineMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/multi/logic/CosmicLargeTurbineMachine.java
@@ -172,7 +172,7 @@ public class CosmicLargeTurbineMachine extends WorkableElectricMultiblockMachine
 
     @Override
     public boolean canVoidRecipeOutputs(RecipeCapability<?> capability) {
-        return capability != EURecipeCapability.CAP;
+        return true;
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
To match the change on Gregtech, this will let the Large Steam Turbine keep running even when the dynamo hatch is full of energy