### PR TITLE
Update MachineBuilder Type Arguments to support the 7.5.0 changes

### DIFF
--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ldlib = "1.0.40.b"
-gtceu = "7.2.0"
+gtceu = "7.5.0-SNAPSHOT"
 registrate = "MC1.20-1.3.11"
 configuration = "3.1.0-forge"
 mixinExtras = "0.2.0"

--- a/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicMachines.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicMachines.java
@@ -604,7 +604,7 @@ public class CosmicMachines {
 
     private static MachineDefinition[] registerTieredMachines(String name,
                                                               BiFunction<IMachineBlockEntity, Integer, MetaMachine> factory,
-                                                              BiFunction<Integer, MachineBuilder<MachineDefinition>, MachineDefinition> builder,
+                                                              BiFunction<Integer, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder,
                                                               int... tiers) {
         MachineDefinition[] definitions = new MachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {

--- a/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicMachinesUtils.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicMachinesUtils.java
@@ -178,14 +178,14 @@ public class CosmicMachinesUtils {
 
     public static MachineDefinition[] registerTieredSingleBlockMachines(String name,
                                                                         BiFunction<IMachineBlockEntity, Integer, MetaMachine> factory,
-                                                                        BiFunction<Integer, MachineBuilder<MachineDefinition>, MachineDefinition> builder,
+                                                                        BiFunction<Integer, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder,
                                                                         int... tiers) {
         return registerTieredMachines(name, factory, builder, tiers);
     }
 
     public static MachineDefinition[] registerTieredMachines(String name,
                                                              BiFunction<IMachineBlockEntity, Integer, MetaMachine> factory,
-                                                             BiFunction<Integer, MachineBuilder<MachineDefinition>, MachineDefinition> builder,
+                                                             BiFunction<Integer, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder,
                                                              int... tiers) {
         MachineDefinition[] definitions = new MachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {
@@ -200,7 +200,7 @@ public class CosmicMachinesUtils {
 
     public static Pair<MachineDefinition, MachineDefinition> registerSteamMachines(String name,
                                                                                    BiFunction<IMachineBlockEntity, Boolean, MetaMachine> factory,
-                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition>, MachineDefinition> builder) {
+                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder) {
         MachineDefinition lowTier = builder.apply(false,
                 REGISTRATE.machine("lp_%s".formatted(name), holder -> factory.apply(holder, false))
                         .langValue("I DO NOT EXIST")

--- a/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicModularMachines.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/data/CosmicModularMachines.java
@@ -50,7 +50,7 @@ public class CosmicModularMachines {
     public static MultiblockMachineDefinition[] registerTieredModules(
                                                                       String name,
                                                                       BiFunction<IMachineBlockEntity, Integer, MultiblockControllerMachine> factory,
-                                                                      BiFunction<Integer, MultiblockMachineBuilder, MultiblockMachineDefinition> builder,
+                                                                      BiFunction<Integer, MultiblockMachineBuilder<?,?>, MultiblockMachineDefinition> builder,
                                                                       int... tiers) {
         MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {


### PR DESCRIPTION
Might not even have to be merged, idk if it targets the right branch, but this is the stuff you need to do to make the jar compile for 7.5.0

it's failing on some mixin stuff later
Caused by: java.lang.IllegalArgumentException: The specified resource 'cosmiccore.mixins.json' was invalid or could not be read
 but that seems unrelated to the change I made with machinebuilders