### PR TITLE
Use correct EUt multiplier for weak steam parallel machines

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/machine/multiblock/steam/WeakSteamParallelMultiBlockMachine.java
@@ -34,8 +34,8 @@ public class WeakSteamParallelMultiBlockMachine extends SteamParallelMultiblockM
         // double eutMulti = (euTick * 0.5 * parallel <= 32) ? (parallel * 0.5) : (32.0 / euTick);
 
         return ModifierFunction.builder()
-                .inputModifier(ContentModifier.multiplier(parallel))
-                .outputModifier(ContentModifier.multiplier(parallel))
+                .modifyAllContents(ContentModifier.multiplier(parallel))
+                .eutModifier(ContentModifier.multiplier(parallel))
                 .durationMultiplier(parallel * 0.75)
                 .parallels(parallel)
                 .build();

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/CapacityShardBehavior.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/CapacityShardBehavior.java
@@ -43,7 +43,9 @@ public class CapacityShardBehavior implements IInteractionItem, IAddInformation 
         return ReflectionCapability.get(player).map(reflection -> {
             if (!reflection.hasAwakened()) {
                 player.displayClientMessage(
-                        Component.literal("The shard feels... dormant. Perhaps after you've seen yourself in the mirror.")
+                        Component
+                                .literal(
+                                        "The shard feels... dormant. Perhaps after you've seen yourself in the mirror.")
                                 .withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC),
                         true);
                 return InteractionResultHolder.fail(stack);

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/ScarRemovalBehavior.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/ScarRemovalBehavior.java
@@ -32,8 +32,7 @@ import java.util.Set;
  */
 public class ScarRemovalBehavior implements IInteractionItem, IAddInformation {
 
-    public ScarRemovalBehavior() {
-    }
+    public ScarRemovalBehavior() {}
 
     @Override
     public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand hand) {
@@ -51,7 +50,8 @@ public class ScarRemovalBehavior implements IInteractionItem, IAddInformation {
         return ReflectionCapability.get(player).map(reflection -> {
             if (!reflection.hasAwakened()) {
                 player.displayClientMessage(
-                        Component.literal("The cluster feels... dormant. Perhaps after you've seen yourself in the mirror.")
+                        Component.literal(
+                                "The cluster feels... dormant. Perhaps after you've seen yourself in the mirror.")
                                 .withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC),
                         true);
                 return InteractionResultHolder.fail(stack);

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/ui/ScarSelectionScreen.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/ui/ScarSelectionScreen.java
@@ -84,7 +84,8 @@ public class ScarSelectionScreen extends Screen {
         graphics.drawCenteredString(font, title, width / 2, listStartY - 30, withAlpha(0xFFBB99DD, 1f));
 
         // Subtitle
-        graphics.drawCenteredString(font, "Choose which scar to heal", width / 2, listStartY - 16, withAlpha(0xFF888888, 1f));
+        graphics.drawCenteredString(font, "Choose which scar to heal", width / 2, listStartY - 16,
+                withAlpha(0xFF888888, 1f));
 
         // Entries
         hoveredIndex = -1;
@@ -98,8 +99,7 @@ public class ScarSelectionScreen extends Screen {
             int x = (width - ENTRY_WIDTH) / 2;
             int y = listStartY + i * (ENTRY_HEIGHT + ENTRY_SPACING);
 
-            boolean hovered = mouseX >= x && mouseX < x + ENTRY_WIDTH
-                    && mouseY >= y && mouseY < y + ENTRY_HEIGHT;
+            boolean hovered = mouseX >= x && mouseX < x + ENTRY_WIDTH && mouseY >= y && mouseY < y + ENTRY_HEIGHT;
             if (hovered) hoveredIndex = entryIndex;
 
             renderEntry(graphics, entry, x, y, hovered);


### PR DESCRIPTION
Fixes 2 bugs:
1. by only modifying input and output, we didn't modify tickinput and tickoutput, so those would never get parallels
2. on top of that, EUt (or in this case steam) gets applied with a seperate eutModifier() call

Before:
<img width="960" height="527" alt="image" src="https://github.com/user-attachments/assets/9437a0ed-fbd0-4d1b-a1f4-6e59c059821c" />

After:
<img width="464" height="312" alt="image" src="https://github.com/user-attachments/assets/8031d4bb-6a0c-47b2-a5a6-30ac4e768b60" />

Also spotless'd lol 
