### PR TITLE
Fix ember capability paralelling

### DIFF
--- a/src/main/java/com/ghostipedia/cosmiccore/api/capability/recipe/EmberRecipeCapability.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/api/capability/recipe/EmberRecipeCapability.java
@@ -5,49 +5,24 @@ import com.ghostipedia.cosmiccore.api.recipe.lookup.MapEmberIngredient;
 
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.IRecipeCapabilityHolder;
-import com.gregtechceu.gtceu.api.capability.recipe.IRecipeHandler;
-import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
-import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
-import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
-import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroup;
-import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroupDistinctness;
-import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.content.SerializerDouble;
-import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
-import com.gregtechceu.gtceu.api.recipe.ingredient.IntCircuitIngredient;
-import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
-import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.AbstractMapIngredient;
 
-import com.gregtechceu.gtceu.utils.GTMath;
-import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
-import it.unimi.dsi.fastutil.objects.Object2LongMap;
-import it.unimi.dsi.fastutil.objects.Object2LongMaps;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenCustomHashMap;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import net.minecraft.network.chat.Component;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static com.gregtechceu.gtceu.api.recipe.RecipeHelper.addToRecipeHandlerMap;
 
 public class EmberRecipeCapability extends RecipeCapability<Double> {
 
@@ -80,20 +55,21 @@ public class EmberRecipeCapability extends RecipeCapability<Double> {
         return super.compressIngredients(ingredients);
     }
 
-    private static Double getInputContents(IRecipeCapabilityHolder holder) {
+    private static double getInputContents(IRecipeCapabilityHolder holder) {
         var handlerLists = holder.getCapabilitiesForIO(IO.IN);
         if (handlerLists.isEmpty()) return 0d;
 
-        Double total = 0d;
+        double total = 0d;
 
         for (var handlerList : handlerLists) {
             if (!handlerList.hasCapability(EmberRecipeCapability.CAP)) continue;
             var emberHandlers = handlerList.getCapability(EmberRecipeCapability.CAP);
-            for(var handler : emberHandlers){
+            for (var handler : emberHandlers) {
                 var emberHandler = (NotifiableEmberContainer) handler;
-                for(var content : handler.getContents()){
-                    // At most, an ember hatch can contribute the minimum of the max allowed consumption per tick, or the current amount stored
-                    total += Math.min((Double) content, emberHandler.getMaxConsumption());
+                for (var content : handler.getContents()) {
+                    // At most, an ember hatch can contribute the minimum of the max allowed consumption per tick, or
+                    // the current amount stored
+                    total += Math.min((double) content, emberHandler.getMaxConsumption());
                 }
             }
         }
@@ -107,16 +83,13 @@ public class EmberRecipeCapability extends RecipeCapability<Double> {
         var inputs = (tick ? recipe.tickInputs : recipe.inputs).get(this);
         if (inputs == null || inputs.isEmpty()) return limit;
 
-        // Find all the items in the combined Item Input inventories and create oversized ItemStacks
         double totalEmberInHatches = getInputContents(holder);
         if (totalEmberInHatches == 0) return 0;
 
-        // map the recipe ingredients to account for duplicated and notConsumable ingredients.
-        // notConsumable ingredients are not counted towards the max ratio
         var nonConsumable = 0d;
         var consumable = 0d;
         for (Content content : inputs) {
-            double required = (Double) content.content;
+            double required = (double) content.content;
 
             if (content.chance == 0) {
                 nonConsumable += required;
@@ -127,9 +100,9 @@ public class EmberRecipeCapability extends RecipeCapability<Double> {
 
         if (consumable == 0 && nonConsumable == 0) return limit;
 
-        if(nonConsumable > totalEmberInHatches) return 0;
-        if(consumable == 0) return limit;
-        return (int) Math.min(limit, totalEmberInHatches / consumable);
+        if (nonConsumable > totalEmberInHatches) return 0;
+        if (consumable == 0) return limit;
+        return (int) Math.min(limit, (totalEmberInHatches - nonConsumable) / consumable);
     }
 
     @Override

--- a/src/main/java/com/ghostipedia/cosmiccore/api/capability/recipe/EmberRecipeCapability.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/api/capability/recipe/EmberRecipeCapability.java
@@ -1,25 +1,53 @@
 package com.ghostipedia.cosmiccore.api.capability.recipe;
 
+import com.ghostipedia.cosmiccore.api.machine.trait.NotifiableEmberContainer;
 import com.ghostipedia.cosmiccore.api.recipe.lookup.MapEmberIngredient;
 
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.IRecipeCapabilityHolder;
+import com.gregtechceu.gtceu.api.capability.recipe.IRecipeHandler;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
+import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroup;
+import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroupDistinctness;
+import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.content.SerializerDouble;
+import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
+import com.gregtechceu.gtceu.api.recipe.ingredient.IntCircuitIngredient;
+import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
+import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.AbstractMapIngredient;
 
+import com.gregtechceu.gtceu.utils.GTMath;
+import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMaps;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import net.minecraft.network.chat.Component;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static com.gregtechceu.gtceu.api.recipe.RecipeHelper.addToRecipeHandlerMap;
 
 public class EmberRecipeCapability extends RecipeCapability<Double> {
 
@@ -50,6 +78,58 @@ public class EmberRecipeCapability extends RecipeCapability<Double> {
     public List<Object> compressIngredients(Collection<Object> ingredients) {
         // TODO: Figure out what it needs to do
         return super.compressIngredients(ingredients);
+    }
+
+    private static Double getInputContents(IRecipeCapabilityHolder holder) {
+        var handlerLists = holder.getCapabilitiesForIO(IO.IN);
+        if (handlerLists.isEmpty()) return 0d;
+
+        Double total = 0d;
+
+        for (var handlerList : handlerLists) {
+            if (!handlerList.hasCapability(EmberRecipeCapability.CAP)) continue;
+            var emberHandlers = handlerList.getCapability(EmberRecipeCapability.CAP);
+            for(var handler : emberHandlers){
+                var emberHandler = (NotifiableEmberContainer) handler;
+                for(var content : handler.getContents()){
+                    // At most, an ember hatch can contribute the minimum of the max allowed consumption per tick, or the current amount stored
+                    total += Math.min((Double) content, emberHandler.getMaxConsumption());
+                }
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public int getMaxParallelByInput(IRecipeCapabilityHolder holder, GTRecipe recipe, int limit, boolean tick) {
+        if (!holder.hasCapabilityProxies()) return 0;
+
+        var inputs = (tick ? recipe.tickInputs : recipe.inputs).get(this);
+        if (inputs == null || inputs.isEmpty()) return limit;
+
+        // Find all the items in the combined Item Input inventories and create oversized ItemStacks
+        double totalEmberInHatches = getInputContents(holder);
+        if (totalEmberInHatches == 0) return 0;
+
+        // map the recipe ingredients to account for duplicated and notConsumable ingredients.
+        // notConsumable ingredients are not counted towards the max ratio
+        var nonConsumable = 0d;
+        var consumable = 0d;
+        for (Content content : inputs) {
+            double required = (Double) content.content;
+
+            if (content.chance == 0) {
+                nonConsumable += required;
+            } else {
+                consumable += required;
+            }
+        }
+
+        if (consumable == 0 && nonConsumable == 0) return limit;
+
+        if(nonConsumable > totalEmberInHatches) return 0;
+        if(consumable == 0) return limit;
+        return (int) Math.min(limit, totalEmberInHatches / consumable);
     }
 
     @Override

--- a/src/main/java/com/ghostipedia/cosmiccore/api/machine/trait/NotifiableEmberContainer.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/api/machine/trait/NotifiableEmberContainer.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
+import lombok.Getter;
 import net.minecraft.nbt.CompoundTag;
 
 import com.rekindled.embers.api.power.IEmberCapability;
@@ -67,9 +68,11 @@ public class NotifiableEmberContainer extends NotifiableRecipeHandlerTrait<Doubl
     private final IO handlerIO;
 
     @Persisted
+    @Getter
     private double maxCapacity;
 
     @Persisted
+    @Getter
     private double maxConsumption;
 
     public NotifiableEmberContainer(MetaMachine machine, IO io, double maxCapacity, double maxConsumption) {

--- a/src/main/java/com/ghostipedia/cosmiccore/api/machine/trait/NotifiableEmberContainer.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/api/machine/trait/NotifiableEmberContainer.java
@@ -12,11 +12,11 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
-import lombok.Getter;
 import net.minecraft.nbt.CompoundTag;
 
 import com.rekindled.embers.api.power.IEmberCapability;
 import com.rekindled.embers.power.DefaultEmberCapability;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/CapacityShardBehavior.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/CapacityShardBehavior.java
@@ -43,7 +43,9 @@ public class CapacityShardBehavior implements IInteractionItem, IAddInformation 
         return ReflectionCapability.get(player).map(reflection -> {
             if (!reflection.hasAwakened()) {
                 player.displayClientMessage(
-                        Component.literal("The shard feels... dormant. Perhaps after you've seen yourself in the mirror.")
+                        Component
+                                .literal(
+                                        "The shard feels... dormant. Perhaps after you've seen yourself in the mirror.")
                                 .withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC),
                         true);
                 return InteractionResultHolder.fail(stack);

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/ScarRemovalBehavior.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/item/ScarRemovalBehavior.java
@@ -32,8 +32,7 @@ import java.util.Set;
  */
 public class ScarRemovalBehavior implements IInteractionItem, IAddInformation {
 
-    public ScarRemovalBehavior() {
-    }
+    public ScarRemovalBehavior() {}
 
     @Override
     public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand hand) {
@@ -51,7 +50,8 @@ public class ScarRemovalBehavior implements IInteractionItem, IAddInformation {
         return ReflectionCapability.get(player).map(reflection -> {
             if (!reflection.hasAwakened()) {
                 player.displayClientMessage(
-                        Component.literal("The cluster feels... dormant. Perhaps after you've seen yourself in the mirror.")
+                        Component.literal(
+                                "The cluster feels... dormant. Perhaps after you've seen yourself in the mirror.")
                                 .withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC),
                         true);
                 return InteractionResultHolder.fail(stack);

--- a/src/main/java/com/ghostipedia/cosmiccore/common/reflection/ui/ScarSelectionScreen.java
+++ b/src/main/java/com/ghostipedia/cosmiccore/common/reflection/ui/ScarSelectionScreen.java
@@ -84,7 +84,8 @@ public class ScarSelectionScreen extends Screen {
         graphics.drawCenteredString(font, title, width / 2, listStartY - 30, withAlpha(0xFFBB99DD, 1f));
 
         // Subtitle
-        graphics.drawCenteredString(font, "Choose which scar to heal", width / 2, listStartY - 16, withAlpha(0xFF888888, 1f));
+        graphics.drawCenteredString(font, "Choose which scar to heal", width / 2, listStartY - 16,
+                withAlpha(0xFF888888, 1f));
 
         // Entries
         hoveredIndex = -1;
@@ -98,8 +99,7 @@ public class ScarSelectionScreen extends Screen {
             int x = (width - ENTRY_WIDTH) / 2;
             int y = listStartY + i * (ENTRY_HEIGHT + ENTRY_SPACING);
 
-            boolean hovered = mouseX >= x && mouseX < x + ENTRY_WIDTH
-                    && mouseY >= y && mouseY < y + ENTRY_HEIGHT;
+            boolean hovered = mouseX >= x && mouseX < x + ENTRY_WIDTH && mouseY >= y && mouseY < y + ENTRY_HEIGHT;
             if (hovered) hoveredIndex = entryIndex;
 
             renderEntry(graphics, entry, x, y, hovered);


### PR DESCRIPTION
Actually take ember into account when calculating max parallel instead of saying "yeah just take as much as you want"
Specifically taking into account how much ember/t we can use per hatch.

Impl was copied from itemrecipecapability and heavily gutted to work with ember, it works in-game.

Fixes the bug where an LV ember hatch (2000/t I/O) machine would try to calculate parallels for 4 recipes at 750/t, not care, try to run 4 of them, then fail when actually starting consumption